### PR TITLE
[ENH] use pytorch 2.0.0 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM pytorch/pytorch:2.0.0-cuda11.7-cudnn8-runtime
 WORKDIR /opt/wsinfer
 COPY . .
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends gcc git libopenslide0 \
+    && apt-get install -y --no-install-recommends gcc g++ git libopenslide0 \
     && python -m pip install --no-cache-dir --editable . \
         --find-links https://girder.github.io/large_image_wheels \
     && apt-get autoremove --yes gcc \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends gcc g++ git libopenslide0 \
     && python -m pip install --no-cache-dir --editable . \
         --find-links https://girder.github.io/large_image_wheels \
-    && apt-get autoremove --yes gcc \
     && rm -rf /var/lib/apt/lists/*
 # Use a writable directory for downloading model weights. Default is ~/.cache, which is
 # not guaranteed to be writable in a Docker container.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:1.12.1-cuda11.3-cudnn8-runtime
+FROM pytorch/pytorch:2.0.0-cuda11.7-cudnn8-runtime
 WORKDIR /opt/wsinfer
 COPY . .
 RUN apt-get update \


### PR DESCRIPTION
fixes #111 