### PR TITLE
clone batch_coords tensor to prevent Too many open files error

### DIFF
--- a/wsinfer/modellib/run_inference.py
+++ b/wsinfer/modellib/run_inference.py
@@ -170,7 +170,10 @@ def run_inference(
                 probs = torch.nn.functional.softmax(logits, dim=1)
             else:
                 probs = torch.sigmoid(logits.squeeze(1))
-            slide_coords.append(batch_coords.numpy())
+            # Cloning the tensor prevents memory accumulation and prevents
+            # the error "RuntimeError: Too many open files". Jakub ran into this
+            # error when running wsinfer on a slide in Windows Subsystem for Linux.
+            slide_coords.append(batch_coords.clone().numpy())
             slide_probs.append(probs.numpy())
 
         slide_coords_arr = np.concatenate(slide_coords, axis=0)


### PR DESCRIPTION
When running wsinfer in a windows subsystem for linux environment, i got the error below. Appending a tensor from the dataloader to a list can cause this issue, and cloning the tensor solves it. This commit clones the tensor.

```
RuntimeError: Too many open files. Communication with the workers is no longer possible. Please increase the limit using `ulimit -n` in the shell or change the sharing strategy by calling `torch.multiprocessing.set_sharing_strategy('file_system')` at the beginning of your code
```

related to https://github.com/pytorch/pytorch/issues/11201