### PR TITLE
restrict wsi_dir.glob to files

### DIFF
--- a/wsinfer/cli/infer.py
+++ b/wsinfer/cli/infer.py
@@ -301,7 +301,7 @@ def run(
     # different directory, both directories need to be bind mounted onto the container.
     # If only the symlinked directory is included, then the patching script will fail,
     # even though it looks like there are files in the wsi_dir directory.
-    files_in_wsi_dir = [p for p in wsi_dir.glob("*.*") if p.exists()]
+    files_in_wsi_dir = [p for p in wsi_dir.iterdir() if p.is_file()]
     if not files_in_wsi_dir:
         raise FileNotFoundError(f"no files exist in the slide directory: {wsi_dir}")
 

--- a/wsinfer/cli/infer.py
+++ b/wsinfer/cli/infer.py
@@ -301,7 +301,7 @@ def run(
     # different directory, both directories need to be bind mounted onto the container.
     # If only the symlinked directory is included, then the patching script will fail,
     # even though it looks like there are files in the wsi_dir directory.
-    files_in_wsi_dir = [p for p in wsi_dir.glob("*") if p.exists()]
+    files_in_wsi_dir = [p for p in wsi_dir.glob("*.*") if p.exists()]
     if not files_in_wsi_dir:
         raise FileNotFoundError(f"no files exist in the slide directory: {wsi_dir}")
 

--- a/wsinfer/modellib/run_inference.py
+++ b/wsinfer/modellib/run_inference.py
@@ -69,7 +69,7 @@ def run_inference(
     wsi_dir = Path(wsi_dir)
     if not wsi_dir.exists():
         raise errors.WholeSlideImageDirectoryNotFound(f"directory not found: {wsi_dir}")
-    wsi_paths = list(wsi_dir.glob("*.*"))
+    wsi_paths = [p for p in wsi_dir.iterdir() if p.is_file()]
     if not wsi_paths:
         raise errors.WholeSlideImagesNotFound(wsi_dir)
     results_dir = Path(results_dir)

--- a/wsinfer/modellib/run_inference.py
+++ b/wsinfer/modellib/run_inference.py
@@ -69,7 +69,7 @@ def run_inference(
     wsi_dir = Path(wsi_dir)
     if not wsi_dir.exists():
         raise errors.WholeSlideImageDirectoryNotFound(f"directory not found: {wsi_dir}")
-    wsi_paths = list(wsi_dir.glob("*"))
+    wsi_paths = list(wsi_dir.glob("*.*"))
     if not wsi_paths:
         raise errors.WholeSlideImagesNotFound(wsi_dir)
     results_dir = Path(results_dir)

--- a/wsinfer/patchlib/__init__.py
+++ b/wsinfer/patchlib/__init__.py
@@ -347,7 +347,7 @@ def segment_and_patch_directory_of_slides(
 
     _validate_wsi_directory(wsi_dir)
 
-    slide_paths = sorted(wsi_dir.glob("*.*"))
+    slide_paths = sorted([p for p in wsi_dir.iterdir() if p.is_file()])
 
     # NOTE: we could use multi-processing here but then the logs would get
     # discombobulated.

--- a/wsinfer/patchlib/__init__.py
+++ b/wsinfer/patchlib/__init__.py
@@ -347,7 +347,7 @@ def segment_and_patch_directory_of_slides(
 
     _validate_wsi_directory(wsi_dir)
 
-    slide_paths = sorted(wsi_dir.glob("*"))
+    slide_paths = sorted(wsi_dir.glob("*.*"))
 
     # NOTE: we could use multi-processing here but then the logs would get
     # discombobulated.

--- a/wsinfer/wsi.py
+++ b/wsinfer/wsi.py
@@ -290,7 +290,7 @@ def get_avg_mpp(slide_path: Path | str) -> float:
 def _validate_wsi_directory(wsi_dir: str | Path) -> None:
     """Validate a directory of whole slide images."""
     wsi_dir = Path(wsi_dir)
-    maybe_slides = sorted(wsi_dir.glob("*"))
+    maybe_slides = sorted(wsi_dir.glob("*.*"))
     uniq_stems = set(p.stem for p in maybe_slides)
     if len(uniq_stems) != len(maybe_slides):
         raise DuplicateFilePrefixesFound(

--- a/wsinfer/wsi.py
+++ b/wsinfer/wsi.py
@@ -290,7 +290,7 @@ def get_avg_mpp(slide_path: Path | str) -> float:
 def _validate_wsi_directory(wsi_dir: str | Path) -> None:
     """Validate a directory of whole slide images."""
     wsi_dir = Path(wsi_dir)
-    maybe_slides = sorted(wsi_dir.glob("*.*"))
+    maybe_slides = [p for p in wsi_dir.iterdir() if p.is_file()]
     uniq_stems = set(p.stem for p in maybe_slides)
     if len(uniq_stems) != len(maybe_slides):
         raise DuplicateFilePrefixesFound(


### PR DESCRIPTION
fixes #189 

this could also be done differently, e.g. `glob("*")` or `iterdir` + checking if `is_dir`