### PR TITLE
Add segmentation options to wsinfer run

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-    "python.linting.enabled": true,
-    "python.linting.flake8Enabled": true,
-    "python.linting.mypyEnabled": true,
-    "python.linting.lintOnSave": true,
-    "editor.formatOnSave": true,
-    "python.formatting.provider": "black",
-}

--- a/wsinfer/qupath.py
+++ b/wsinfer/qupath.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import sys
 import json
+import sys
 from pathlib import Path
 
 try:


### PR DESCRIPTION
in some cases, it is desirable to customize the tissue segmentation parameters. the defaults may under- or over-estimate tissue.

related to #213  -- in that issue, the entire image was interpreted as tissue using the defaults. changing the binary threshold to 12 resulted in a good segmentation.