### PR TITLE
Cleanup + add strided patches

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -6,7 +6,6 @@ import platform
 import sys
 import time
 from pathlib import Path
-from unittest.mock import patch as mock_patch, MagicMock
 
 import geojson as geojsonlib
 import h5py

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -512,3 +512,24 @@ def test_issue_125(tmp_path: Path) -> None:
     info = _get_info_for_save(w)
     with open(tmp_path / "foo.json", "w") as f:
         json.dump(info, f)
+
+
+def test_issue_203(tiff_image: Path) -> None:
+    """Test that openslide and tiffslide pad an image if an out-of-bounds region
+    is requested.
+    """
+    import openslide
+    import tiffslide
+
+    with tiffslide.TiffSlide(tiff_image) as tslide:
+        w, h = tslide.dimensions
+        img = tslide.read_region((w, h), level=0, size=(256, 256))
+        assert img.size == (256, 256)
+        assert np.allclose(np.array(img), 0)
+    del tslide, img
+
+    with openslide.OpenSlide(tiff_image) as oslide:
+        w, h = oslide.dimensions
+        img = oslide.read_region((w, h), level=0, size=(256, 256))
+        assert img.size == (256, 256)
+        assert np.allclose(np.array(img), 0)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -145,7 +145,7 @@ def test_cli_run_with_registered_models(
     geojson_dir = results_dir / "model-outputs-geojson"
     # result = runner.invoke(cli, ["togeojson", str(results_dir), str(geojson_dir)])
     assert result.exit_code == 0
-    with open(geojson_dir / "purple.json") as f:
+    with open(geojson_dir / "purple.geojson") as f:
         d: geojsonlib.GeoJSON = geojsonlib.load(f)
     assert d.is_valid, "geojson not valid!"
     assert len(d["features"]) == len(df_ref)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -6,6 +6,7 @@ import platform
 import sys
 import time
 from pathlib import Path
+from unittest.mock import patch as mock_patch, MagicMock
 
 import geojson as geojsonlib
 import h5py
@@ -23,6 +24,7 @@ from wsinfer.modellib.models import get_registered_model
 from wsinfer.modellib.run_inference import jit_compile
 from wsinfer.wsi import HAS_OPENSLIDE
 from wsinfer.wsi import HAS_TIFFSLIDE
+
 
 @pytest.fixture
 def tiff_image(tmp_path: Path) -> Path:
@@ -82,7 +84,7 @@ def test_cli_run_with_registered_models(
     backend: str,
     tiff_image: Path,
     tmp_path: Path,
-):
+) -> None:
     """A regression test of the command 'wsinfer run'."""
 
     reference_csv = Path(__file__).parent / "reference" / model / "purple.csv"
@@ -151,7 +153,7 @@ def test_cli_run_with_registered_models(
 
     for geojson_row in d["features"]:
         assert geojson_row["type"] == "Feature"
-        isinstance(geojson_row["id"] , str)
+        isinstance(geojson_row["id"], str)
         assert geojson_row["geometry"]["type"] == "Polygon"
     res = []
     for i, prob_col in enumerate(prob_cols):
@@ -178,7 +180,7 @@ def test_cli_run_with_registered_models(
         assert [df_coords] == geojson_row["geometry"]["coordinates"]
 
 
-def test_cli_run_with_local_model(tmp_path: Path, tiff_image: Path):
+def test_cli_run_with_local_model(tmp_path: Path, tiff_image: Path) -> None:
     model = "breast-tumor-resnet34.tcga-brca"
     reference_csv = Path(__file__).parent / "reference" / model / "purple.csv"
     if not reference_csv.exists():
@@ -246,7 +248,7 @@ def test_cli_run_with_local_model(tmp_path: Path, tiff_image: Path):
         ), f"Column {prob_col} not allclose at atol=1e-07"
 
 
-def test_cli_run_no_model_or_config(tmp_path: Path):
+def test_cli_run_no_model_or_config(tmp_path: Path) -> None:
     """Test that --model or (--config and --model-path) is required."""
     wsi_dir = tmp_path / "slides"
     wsi_dir.mkdir()
@@ -265,7 +267,7 @@ def test_cli_run_no_model_or_config(tmp_path: Path):
     assert "one of --model or (--config and --model-path) is required" in result.output
 
 
-def test_cli_run_model_and_config(tmp_path: Path):
+def test_cli_run_model_and_config(tmp_path: Path) -> None:
     """Test that (model and weights) or config is required."""
     wsi_dir = tmp_path / "slides"
     wsi_dir.mkdir()
@@ -298,7 +300,7 @@ def test_cli_run_model_and_config(tmp_path: Path):
 
 
 @pytest.mark.xfail
-def test_convert_to_sbu():
+def test_convert_to_sbu() -> None:
     # TODO: create a synthetic output and then convert it. Check that it is valid.
     assert False
 
@@ -330,7 +332,7 @@ def test_patch_cli(
     backend: str,
     tmp_path: Path,
     tiff_image: Path,
-):
+) -> None:
     """Test of 'wsinfer patch'."""
     orig_slide_size = 4096
     orig_slide_spacing = 0.25
@@ -380,7 +382,7 @@ def test_patch_cli(
 
 
 # FIXME: parametrize this test across our models.
-def test_jit_compile():
+def test_jit_compile() -> None:
     w = get_registered_model("breast-tumor-resnet34.tcga-brca")
     model = get_pretrained_torch_module(w)
 
@@ -411,7 +413,7 @@ def test_jit_compile():
         )
 
 
-def test_issue_89():
+def test_issue_89() -> None:
     """Do not fail if 'git' is not installed."""
     model_obj = get_registered_model("breast-tumor-resnet34.tcga-brca")
     d = _get_info_for_save(model_obj)
@@ -433,7 +435,7 @@ def test_issue_89():
         os.environ["PATH"] = orig_path  # reset path
 
 
-def test_issue_94(tmp_path: Path, tiff_image: Path):
+def test_issue_94(tmp_path: Path, tiff_image: Path) -> None:
     """Gracefully handle unreadable slides."""
 
     # We have a valid tiff in 'tiff_image.parent'. We put in an unreadable file too.
@@ -461,7 +463,7 @@ def test_issue_94(tmp_path: Path, tiff_image: Path):
     assert not results_dir.joinpath("model-outputs-csv").joinpath("bad.csv").exists()
 
 
-def test_issue_97(tmp_path: Path, tiff_image: Path):
+def test_issue_97(tmp_path: Path, tiff_image: Path) -> None:
     """Write a run_metadata file per run."""
 
     runner = CliRunner()
@@ -502,7 +504,7 @@ def test_issue_97(tmp_path: Path, tiff_image: Path):
     assert len(metas) == 2
 
 
-def test_issue_125(tmp_path: Path):
+def test_issue_125(tmp_path: Path) -> None:
     """Test that path in model config can be saved when a pathlib.Path object."""
 
     w = get_registered_model("breast-tumor-resnet34.tcga-brca")

--- a/wsinfer/cli/convert_csv_to_sbubmi.py
+++ b/wsinfer/cli/convert_csv_to_sbubmi.py
@@ -249,21 +249,17 @@ def write_color_txt(
 @click.command()
 @click.argument(
     "results_dir",
-    type=click.Path(
-        exists=True, file_okay=False, dir_okay=True, path_type=Path, resolve_path=True
-    ),
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
 )
 @click.argument(
     "output",
-    type=click.Path(exists=False, path_type=Path, resolve_path=True),
+    type=click.Path(exists=False, path_type=Path),
 )
 @click.option(
     "--wsi-dir",
     required=True,
     help="Directory with whole slide images.",
-    type=click.Path(
-        exists=True, file_okay=False, dir_okay=True, path_type=Path, resolve_path=True
-    ),
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
 )
 @click.option("--execution-id", required=True, help="Unique execution ID for this run.")
 @click.option("--study-id", required=True, help="Study ID, like TCGA-BRCA.")

--- a/wsinfer/cli/infer.py
+++ b/wsinfer/cli/infer.py
@@ -447,9 +447,12 @@ def run(
     with open(run_metadata_outpath, "w") as f:
         json.dump(run_metadata, f, indent=2)
 
-    click.secho("Finished.", fg="green")
-
+    click.echo("Writing inference results to GeoJSON files")
     csvs = list((results_dir / "model-outputs-csv").glob("*.csv"))
     write_geojsons(csvs, results_dir, num_workers)
+
     if qupath:
+        click.echo("Creating QuPath project with results")
         make_qupath_project(wsi_dir, results_dir)
+
+    click.secho("Finished.", fg="green")

--- a/wsinfer/cli/infer.py
+++ b/wsinfer/cli/infer.py
@@ -188,7 +188,7 @@ def _get_info_for_save(
 @click.option(
     "-i",
     "--wsi-dir",
-    type=click.Path(exists=True, file_okay=False, path_type=Path, resolve_path=True),
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
     required=True,
     help="Directory containing whole slide images. This directory can *only* contain"
     " whole slide images.",
@@ -196,7 +196,7 @@ def _get_info_for_save(
 @click.option(
     "-o",
     "--results-dir",
-    type=click.Path(file_okay=False, path_type=Path, resolve_path=True),
+    type=click.Path(file_okay=False, path_type=Path),
     required=True,
     help="Directory to store results. If directory exists, will skip"
     " whole slides for which outputs exist.",
@@ -212,7 +212,7 @@ def _get_info_for_save(
 @click.option(
     "-c",
     "--config",
-    type=click.Path(exists=True, dir_okay=False, path_type=Path, resolve_path=True),
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
     help=(
         "Path to configuration for the trained model. Use this option if the"
         " model weights are not registered in wsinfer. Mutually exclusive with"
@@ -222,7 +222,7 @@ def _get_info_for_save(
 @click.option(
     "-p",
     "--model-path",
-    type=click.Path(exists=True, dir_okay=False, path_type=Path, resolve_path=True),
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
     help=(
         "Path to the pretrained model. Use only when --config is passed. Mutually "
         "exclusive with --model."
@@ -348,9 +348,6 @@ def run(
         raise click.UsageError(
             "--config and --model-path must both be set if one is set."
         )
-
-    wsi_dir = wsi_dir.resolve()
-    results_dir = results_dir.resolve()
 
     if not wsi_dir.exists():
         raise FileNotFoundError(f"Whole slide image directory not found: {wsi_dir}")

--- a/wsinfer/cli/infer.py
+++ b/wsinfer/cli/infer.py
@@ -303,6 +303,16 @@ def _get_info_for_save(
     " area, it is filled with foreground. The default is 190um x 190um. The units of"
     " this argument are microns squared.",
 )
+@click.option(
+    "--patch-overlap-ratio",
+    default=0.0,
+    type=click.FloatRange(min=None, max=1, max_open=True),
+    help="The ratio of overlap among patches. The default value of 0 produces"
+    " non-overlapping patches. A value in (0, 1) will produce overlapping patches."
+    " Negative values will add space between patches. A value of -1 would skip"
+    " every other patch. A value of 0.5 will provide 50%% of overlap between patches."
+    " Values must be in (-inf, 1).",
+)
 def run(
     ctx: click.Context,
     *,
@@ -321,6 +331,7 @@ def run(
     seg_closing_kernel_size: int,
     seg_min_object_size_um2: float,
     seg_min_hole_size_um2: float,
+    patch_overlap_ratio: float = 0.0,
 ) -> None:
     """Run model inference on a directory of whole slide images.
 
@@ -398,6 +409,7 @@ def run(
         closing_kernel_size=seg_closing_kernel_size,
         min_object_size_um2=seg_min_object_size_um2,
         min_hole_size_um2=seg_min_hole_size_um2,
+        overlap=patch_overlap_ratio,
     )
 
     if not results_dir.joinpath("patches").exists():

--- a/wsinfer/cli/patch.py
+++ b/wsinfer/cli/patch.py
@@ -11,7 +11,7 @@ from ..patchlib import segment_and_patch_directory_of_slides
 @click.option(
     "-i",
     "--wsi-dir",
-    type=click.Path(exists=True, file_okay=False, path_type=Path, resolve_path=True),
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
     required=True,
     help="Directory containing whole slide images. This directory can *only* contain"
     " whole slide images.",
@@ -19,7 +19,7 @@ from ..patchlib import segment_and_patch_directory_of_slides
 @click.option(
     "-o",
     "--results-dir",
-    type=click.Path(file_okay=False, path_type=Path, resolve_path=True),
+    type=click.Path(file_okay=False, path_type=Path),
     required=True,
     help="Directory to store patch results. If directory exists, will skip"
     " whole slides for which outputs exist.",
@@ -32,7 +32,7 @@ from ..patchlib import segment_and_patch_directory_of_slides
     help="Physical spacing of the patch in micrometers per pixel.",
 )
 @click.option(
-    "--thumbsize",
+    "--seg-thumbsize",
     default=(2048, 2048),
     type=(int, int),
     help="The size of the slide thumbnail (in pixels) used for tissue segmentation."
@@ -40,25 +40,25 @@ from ..patchlib import segment_and_patch_directory_of_slides
     " max(thumbsize).",
 )
 @click.option(
-    "--median-filter-size",
+    "--seg-median-filter-size",
     default=7,
     type=click.IntRange(min=3),
     help="The kernel size for median filtering. Must be greater than 1 and odd.",
 )
 @click.option(
-    "--binary-threshold",
+    "--seg-binary-threshold",
     default=7,
     type=click.IntRange(min=1),
     help="The threshold for image binarization.",
 )
 @click.option(
-    "--closing-kernel-size",
+    "--seg-closing-kernel-size",
     default=6,
     type=click.IntRange(min=1),
     help="The kernel size for binary closing (morphological operation).",
 )
 @click.option(
-    "--min-object-size-um2",
+    "--seg-min-object-size-um2",
     default=200**2,
     type=click.FloatRange(min=0),
     help="The minimum size of an object to keep during tissue detection. If a"
@@ -66,7 +66,7 @@ from ..patchlib import segment_and_patch_directory_of_slides
     " The default is 200um x 200um. The units of this argument are microns squared.",
 )
 @click.option(
-    "--min-hole-size-um2",
+    "--seg-min-hole-size-um2",
     default=190**2,
     type=click.FloatRange(min=0),
     help="The minimum size of a hole to keep as a hole. If a hole is smaller than this"
@@ -78,12 +78,12 @@ def patch(
     results_dir: str,
     patch_size_px: int,
     patch_spacing_um_px: float,
-    thumbsize: tuple[int, int],
-    median_filter_size: int,
-    binary_threshold: int,
-    closing_kernel_size: int,
-    min_object_size_um2: float,
-    min_hole_size_um2: float,
+    seg_thumbsize: tuple[int, int],
+    seg_median_filter_size: int,
+    seg_binary_threshold: int,
+    seg_closing_kernel_size: int,
+    seg_min_object_size_um2: float,
+    seg_min_hole_size_um2: float,
 ) -> None:
     """Patch a directory of whole slide iamges."""
     segment_and_patch_directory_of_slides(
@@ -91,10 +91,10 @@ def patch(
         save_dir=results_dir,
         patch_size_px=patch_size_px,
         patch_spacing_um_px=patch_spacing_um_px,
-        thumbsize=thumbsize,
-        median_filter_size=median_filter_size,
-        binary_threshold=binary_threshold,
-        closing_kernel_size=closing_kernel_size,
-        min_object_size_um2=min_object_size_um2,
-        min_hole_size_um2=min_hole_size_um2,
+        thumbsize=seg_thumbsize,
+        median_filter_size=seg_median_filter_size,
+        binary_threshold=seg_binary_threshold,
+        closing_kernel_size=seg_closing_kernel_size,
+        min_object_size_um2=seg_min_object_size_um2,
+        min_hole_size_um2=seg_min_hole_size_um2,
     )

--- a/wsinfer/modellib/data.py
+++ b/wsinfer/modellib/data.py
@@ -60,10 +60,6 @@ class WholeSlideImagePatches(torch.utils.data.Dataset):
         Path to whole slide image file.
     patch_path : str, Path
         Path to npy file with coordinates of input image.
-    um_px : float
-        Scale of the resulting patches. For example, 0.5 for ~20x magnification.
-    patch_size : int
-        The size of patches in pixels.
     transform : callable, optional
         A callable to modify a retrieved patch. The callable must accept a
         PIL.Image.Image instance and return a torch.Tensor.
@@ -73,14 +69,10 @@ class WholeSlideImagePatches(torch.utils.data.Dataset):
         self,
         wsi_path: str | Path,
         patch_path: str | Path,
-        um_px: float,
-        patch_size: int,
         transform: Callable[[Image.Image], torch.Tensor] | None = None,
     ):
         self.wsi_path = wsi_path
         self.patch_path = patch_path
-        self.um_px = float(um_px)
-        self.patch_size = int(patch_size)
         self.transform = transform
 
         assert Path(wsi_path).exists(), "wsi path not found"

--- a/wsinfer/modellib/data.py
+++ b/wsinfer/modellib/data.py
@@ -79,7 +79,8 @@ class WholeSlideImagePatches(torch.utils.data.Dataset):
         assert Path(patch_path).exists(), "patch path not found"
 
         self.patches = _read_patch_coords(self.patch_path)
-
+        if self.patches.size == 0:
+            raise ValueError(f"No patches were found in {self.patch_path}")
         assert self.patches.ndim == 2, "expected 2D array of patch coordinates"
         # x, y, width, height
         assert self.patches.shape[1] == 4, "expected second dimension to have len 4"

--- a/wsinfer/modellib/run_inference.py
+++ b/wsinfer/modellib/run_inference.py
@@ -150,8 +150,6 @@ def run_inference(
             dset = WholeSlideImagePatches(
                 wsi_path=wsi_path,
                 patch_path=patch_path,
-                um_px=model_info.config.spacing_um_px,
-                patch_size=model_info.config.patch_size_pixels,
                 transform=transform,
             )
         except Exception:

--- a/wsinfer/modellib/run_inference.py
+++ b/wsinfer/modellib/run_inference.py
@@ -83,7 +83,12 @@ def run_inference(
     # Check patches directory.
     patch_dir = results_dir / "patches"
     if not patch_dir.exists():
-        raise errors.PatchDirectoryNotFound("Results dir must include 'patches' dir")
+        raise errors.PatchDirectoryNotFound(
+            "The 'patches' directory was not found in results directory. This can"
+            " happen for a few reasons: 1) no tissue was detected in the slides,"
+            " 2) the physical spacing (MPP) could not be read from any of the slides"
+            ", or 3) something else... Please read the logs above for potential errors."
+        )
     # Create the patch paths based on the whole slide image paths. In effect, only
     # create patch paths if the whole slide image patch exists.
     patch_paths = [patch_dir / p.with_suffix(".h5").name for p in wsi_paths]

--- a/wsinfer/patchlib/__init__.py
+++ b/wsinfer/patchlib/__init__.py
@@ -14,7 +14,7 @@ from ..wsi import WSI
 from ..wsi import _validate_wsi_directory
 from ..wsi import get_avg_mpp
 from .patch import get_multipolygon_from_binary_arr
-from .patch import get_nonoverlapping_patch_coordinates_within_polygon
+from .patch import get_patch_coordinates_within_polygon
 from .segment import segment_tissue
 
 logger = logging.getLogger(__name__)
@@ -34,6 +34,7 @@ def segment_and_patch_one_slide(
     closing_kernel_size: int = 6,
     min_object_size_um2: float = 200**2,
     min_hole_size_um2: float = 190**2,
+    overlap: float = 0.0,
 ) -> None:
     """Get non-overlapping patch coordinates in tissue regions of a whole slide image.
 
@@ -171,12 +172,13 @@ def segment_and_patch_one_slide(
     half_patch_size = round(patch_size / 2)
 
     # Nx4 --> N x (minx, miny, width, height)
-    coords = get_nonoverlapping_patch_coordinates_within_polygon(
+    coords = get_patch_coordinates_within_polygon(
         slide_width=slide_width,
         slide_height=slide_height,
         patch_size=patch_size,
         half_patch_size=half_patch_size,
         polygon=polygon,
+        overlap=overlap,
     )
     logger.info(f"Found {len(coords)} patches within tissue")
 
@@ -299,6 +301,7 @@ def segment_and_patch_directory_of_slides(
     closing_kernel_size: int = 6,
     min_object_size_um2: float = 200**2,
     min_hole_size_um2: float = 190**2,
+    overlap: float = 0.0,
 ) -> None:
     """Get non-overlapping patch coordinates in tissue regions for a directory of whole
     slide images.
@@ -373,6 +376,7 @@ def segment_and_patch_directory_of_slides(
                 closing_kernel_size=closing_kernel_size,
                 min_object_size_um2=min_object_size_um2,
                 min_hole_size_um2=min_hole_size_um2,
+                overlap=overlap,
             )
         except Exception as e:
             logger.error(f"Failed to segment and patch slide\n{slide_path}", exc_info=e)

--- a/wsinfer/patchlib/__init__.py
+++ b/wsinfer/patchlib/__init__.py
@@ -85,8 +85,8 @@ def segment_and_patch_one_slide(
     None
     """
 
-    save_dir = Path(save_dir).resolve()
-    slide_path = Path(slide_path).resolve()
+    save_dir = Path(save_dir)
+    slide_path = Path(slide_path)
     slide_prefix = slide_path.stem
 
     logger.info(f"Segmenting and patching slide {slide_path}")

--- a/wsinfer/patchlib/__init__.py
+++ b/wsinfer/patchlib/__init__.py
@@ -121,7 +121,9 @@ def segment_and_patch_one_slide(
     if len(thumbsize) != 2:
         raise ValueError(f"Length of 'thumbsize' must be 2 but got {len(thumbsize)}")
     thumb: Image.Image = slide.get_thumbnail(thumbsize)
-    # TODO: allow the min hole size and min object size to be set in physical units.
+    if thumb.mode != "RGB":
+        logger.warning(f"Converting mode of thumbnail from {thumb.mode} to RGB")
+        thumb = thumb.convert("RGB")
 
     # thumb has ~12 MPP.
     thumb_mpp = (mpp * (np.array(slide.dimensions) / thumb.size)).mean()

--- a/wsinfer/patchlib/patch.py
+++ b/wsinfer/patchlib/patch.py
@@ -32,7 +32,7 @@ def temporary_recursion_limit(limit: int) -> Iterator[None]:
 
 def get_multipolygon_from_binary_arr(
     arr: npt.NDArray[np.int_], scale: tuple[float, float] | None = None
-) -> tuple[MultiPolygon, Sequence[npt.NDArray[np.int_]], npt.NDArray[np.int_]]:
+) -> tuple[MultiPolygon, Sequence[npt.NDArray[np.int_]], npt.NDArray[np.int_]] | None:
     """Create a Shapely Polygon from a binary array.
 
     Parameters
@@ -54,8 +54,10 @@ def get_multipolygon_from_binary_arr(
     """
     # Find contours and hierarchy
     contours: Sequence[npt.NDArray]
-    hierarchy: npt.NDArray
+    hierarchy: npt.NDArray | None
     contours, hierarchy = cv.findContours(arr, cv.RETR_CCOMP, cv.CHAIN_APPROX_SIMPLE)
+    if hierarchy is None:
+        return None
     hierarchy = hierarchy.squeeze(0)
 
     logger.info(f"Detected {len(contours)} contours")

--- a/wsinfer/patchlib/patch.py
+++ b/wsinfer/patchlib/patch.py
@@ -100,6 +100,8 @@ def get_multipolygon_from_binary_arr(
                 polygon = polygon.difference(new_poly)
 
         # Check if current polygon has a child
+        if hierarchy is None:
+            raise NotImplementedError()
         child_idx = hierarchy[idx][2]
         if child_idx >= 0:
             # Call this function recursively, negate `add` parameter

--- a/wsinfer/write_geojson.py
+++ b/wsinfer/write_geojson.py
@@ -71,7 +71,7 @@ def make_geojson(csv: Path, results_dir: Path) -> None:
     if not prob_cols:
         raise KeyError("Did not find any columns with prob_ prefix.")
     geojson = _dataframe_to_geojson(df, prob_cols)
-    with open(results_dir / "model-outputs-geojson" / f"{filename}.json", "w") as f:
+    with open(results_dir / "model-outputs-geojson" / f"{filename}.geojson", "w") as f:
         json.dump(geojson, f)
 
 
@@ -95,7 +95,7 @@ def write_geojsons(csvs: list[Path], results_dir: Path, num_workers: int) -> Non
             "that contains model-outputs, masks, and patches."
         )
     if output.exists():
-        geojsons = list((results_dir / "model-outputs-geojson").glob("*.json"))
+        geojsons = list((results_dir / "model-outputs-geojson").glob("*.geojson"))
 
         # Makes a list of filenames for both geojsons and csvs
         geojson_filenames = [filename.stem for filename in geojsons]


### PR DESCRIPTION
The purpose of the PR is to clean up various issues. This PR also adds strided patches (they can be overlapped or spaced apart).

One may use overlapping patches in attempt to smooth out noise. Strided patches with holes may be useful to increase the speed of runtime. If one does not need a dense classification, then strided patches might be useful. An overlap ratio of -1 results results in 4x fewer patches.

## Patches spaced apart (overlap=-1)

```
wsinfer run -m breast-tumor-resnet34.tcga-brca -i slides/ -o outputs-overlap-minus1/ --patch-overlap-ratio -1
```

![image](https://github.com/SBU-BMI/wsinfer/assets/17690870/8e1af60d-65e7-4074-84ba-3c34f6a440d7)


## Patches overlapping by 10% (overlap=0.1)

```
wsinfer run -m breast-tumor-resnet34.tcga-brca -i slides/ -o outputs-overlap-0.5/ --patch-overlap-ratio 0.5
```

![image](https://github.com/SBU-BMI/wsinfer/assets/17690870/f0314af3-45ab-4f73-bc0a-21185e49c098)



## Issues fixed

fixes #216 
fixes #214 
fixes #205 
fixes #203 
fixes #202 
fixes #195 
fixes #185 