### PR TITLE
fix backend setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           test -f results/run_metadata_*.json
           test -f results/patches/JP2K-33003-1.h5
           test -f results/model-outputs-csv/JP2K-33003-1.csv
-          test $(wc -l < results/model-outputs-csv/JP2K-33003-1.csv) -eq 675
+          test $(wc -l < results/model-outputs-csv/JP2K-33003-1.csv) -eq 601
       # FIXME: tissue segmentation has different outputs on Windows. The patch sizes
       # are the same but the coordinates found are different.
       - name: Run 'wsinfer run' on Windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,8 @@ jobs:
       - name: Install the wsinfer python package
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cpu openslide-python tiffslide
+          python -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install numpy openslide-python tiffslide
           python -m pip install .
       - name: Run 'wsinfer run' on Unix
         if: matrix.os != 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
           sudo apt update
           sudo apt install -y libopenslide0
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install --pre torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cpu openslide-python tiffslide
+          python -m pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
+          python -m pip install openslide-python tiffslide
           python -m pip install --editable .[dev]
       - name: Run tests
         run: python -m pytest --verbose tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           test -f results/run_metadata_*.json
           test -f results/patches/JP2K-33003-1.h5
           test -f results/model-outputs-csv/JP2K-33003-1.csv
-          test $(wc -l < results/model-outputs-csv/JP2K-33003-1.csv) -eq 675
+          test $(wc -l < results/model-outputs-csv/JP2K-33003-1.csv) -eq 601
 
   test-package:
     strategy:

--- a/wsinfer/__init__.py
+++ b/wsinfer/__init__.py
@@ -6,19 +6,3 @@ try:
     from ._version import __version__
 except ImportError:
     __version__ = "0.0.unknown"
-
-
-# Patch Zarr. See:
-# https://github.com/bayer-science-for-a-better-life/tiffslide/issues/72#issuecomment-1627918238
-# https://github.com/zarr-developers/zarr-python/pull/1454
-def _patch_zarr_kvstore() -> None:
-    from zarr.storage import KVStore
-
-    def _zarr_KVStore___contains__(self, key):  # type: ignore
-        return key in self._mutable_mapping
-
-    if "__contains__" not in KVStore.__dict__:
-        KVStore.__contains__ = _zarr_KVStore___contains__
-
-
-_patch_zarr_kvstore()

--- a/wsinfer/cli/convert_csv_to_sbubmi.py
+++ b/wsinfer/cli/convert_csv_to_sbubmi.py
@@ -36,7 +36,7 @@ import numpy.typing as npt
 import pandas as pd
 import tqdm
 
-from ..wsi import WSI
+from ..wsi import get_wsi_cls
 from ..wsi import CanReadRegion
 
 
@@ -353,7 +353,8 @@ def tosbu(
             click.secho(f"WSI file not found: {wsi_file}", bg="red")
             click.secho("Skipping...", bg="red")
             continue
-        slide = WSI(wsi_file)
+        wsi_reader = get_wsi_cls()
+        slide = wsi_reader(wsi_file)
 
         slide_width, slide_height = slide.level_dimensions[0]
 

--- a/wsinfer/cli/convert_csv_to_sbubmi.py
+++ b/wsinfer/cli/convert_csv_to_sbubmi.py
@@ -36,8 +36,8 @@ import numpy.typing as npt
 import pandas as pd
 import tqdm
 
-from ..wsi import get_wsi_cls
 from ..wsi import CanReadRegion
+from ..wsi import get_wsi_cls
 
 
 def _box_to_polygon(

--- a/wsinfer/modellib/data.py
+++ b/wsinfer/modellib/data.py
@@ -10,7 +10,7 @@ import numpy.typing as npt
 import torch
 from PIL import Image
 
-from wsinfer.wsi import WSI
+from wsinfer.wsi import get_wsi_cls
 
 
 def _read_patch_coords(path: str | Path) -> npt.NDArray[np.int_]:
@@ -87,7 +87,8 @@ class WholeSlideImagePatches(torch.utils.data.Dataset):
 
     def worker_init(self, worker_id: int | None = None) -> None:
         del worker_id
-        self.slide = WSI(self.wsi_path)
+        wsi_reader = get_wsi_cls()
+        self.slide = wsi_reader(self.wsi_path)
 
     def __len__(self) -> int:
         return self.patches.shape[0]

--- a/wsinfer/patchlib/__init__.py
+++ b/wsinfer/patchlib/__init__.py
@@ -10,7 +10,7 @@ import numpy as np
 import numpy.typing as npt
 from PIL import Image
 
-from ..wsi import WSI
+from ..wsi import get_wsi_cls
 from ..wsi import _validate_wsi_directory
 from ..wsi import get_avg_mpp
 from .patch import get_multipolygon_from_binary_arr
@@ -103,7 +103,7 @@ def segment_and_patch_one_slide(
         logger.info(f"mask_path={mask_path}")
         return None
 
-    slide = WSI(slide_path)
+    slide = get_wsi_cls()(slide_path)
     mpp = get_avg_mpp(slide_path)
     logger.info(f"Slide has WxH {slide.dimensions} and MPP={mpp}")
 

--- a/wsinfer/patchlib/__init__.py
+++ b/wsinfer/patchlib/__init__.py
@@ -10,9 +10,9 @@ import numpy as np
 import numpy.typing as npt
 from PIL import Image
 
-from ..wsi import get_wsi_cls
 from ..wsi import _validate_wsi_directory
 from ..wsi import get_avg_mpp
+from ..wsi import get_wsi_cls
 from .patch import get_multipolygon_from_binary_arr
 from .patch import get_patch_coordinates_within_polygon
 from .segment import segment_tissue

--- a/wsinfer/wsi.py
+++ b/wsinfer/wsi.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 import logging
 from fractions import Fraction
 from pathlib import Path
-from typing import Literal
 from typing import Protocol
-from typing import overload
 
 import tifffile
 from PIL import Image


### PR DESCRIPTION
fixes #225 

this rewords the `wsinfer.wsi` namespace and introduces a new function `wsinfer.wsi.get_wsi_cls()` to get the correct constructor (either `openslide.OpenSlide` or `tiffslide.TiffSlide`).